### PR TITLE
Put into docker with docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/*
 .vscode
 
+code/obj/**
 *.o
 Answer.cpp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:bionic
 
-RUN apt-get update && apt-get install -y build-essential
+RUN apt-get update && apt-get install -y build-essential python3 python3-pip
+
+COPY ./requirements.txt .
+RUN pip3 install -r requirements.txt
 
 VOLUME [ "/build" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y build-essential
+
+VOLUME [ "/build" ]
+
+WORKDIR /build
+
+RUN mkdir /build/obj
+
+CMD ["make", "all"]

--- a/code/makefile
+++ b/code/makefile
@@ -9,7 +9,7 @@ OBJ= main.o detour.o maze.o robot.o mapAdapter.o
 
 .PHONY: all
 
-all: CXXFLAGS += -O3
+all: CXXFLAGS += -Osize
 all: STRIP=1
 all: $(TARGET) 
 

--- a/code/makefile
+++ b/code/makefile
@@ -1,23 +1,44 @@
-CC = g++
-CCFLAGS =
-OBJS = $(shell ls *.cpp|sed --expression='s/.cpp/.o/g')
-EXE = exe_bin
-NOSTRIP = 0
+CXX = g++
+OBJDIR:=$(shell [ -d obj ] || mkdir obj && echo "obj")
+CXXFLAGS+=-Wall -Wextra -std=c++17
+LDFLAGS=
+STRIP=1 
 
-ifeq ("$(DEBUG)","1")
-	CCFLAGS += -g -DDEBUG
-	NOSTRIP = 1
-endif
+TARGET = exe_bin
+OBJ= main.o detour.o maze.o robot.o mapAdapter.o
 
-%.o:%.cpp
-	$(CC) $(CCFLAGS) -c -o $@ $<
+.PHONY: all
 
-all:$(OBJS)
-	$(CC) $(OBJS) -o $(EXE)
-	if [ "$(NOSTRIP)" = "0" ]; then \
-		strip $(EXE); \
+all: CXXFLAGS += -O3
+all: STRIP=1
+all: $(TARGET) 
+
+debug: CXXFLAGS += -g -DDEBUG -fsanitize=leak -fsanitize=undefined
+debug: LDFLAGS += -fsanitize=address -lubsan -lasan 
+debug: STRIP=0
+debug: $(TARGET)
+
+dev: CXXFLAGS += -g -DDEBUG
+dev: STRIP=0
+dev: $(TARGET)
+
+finalize: $(TARGET)
+	if [ $(STRIP) = "1" ]; then \
+		strip $(TARGET); \
 	fi
-	cat $(EXE)|base64 > $(EXE).b64
+	cat $(TARGET)|base64 > $(TARGET).b64
+
+.SECONDEXPANSION:
+$(TARGET): $(patsubst %, $(OBJDIR)/%, $(OBJ))
+	$(CXX) $(filter %.o, $^) -o $@ $(LDFLAGS)
+
+$(OBJDIR)/%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+$(OBJDIR)/%.d: %.cpp
+	$(CXX) -MM $(CXXFLAGS) -o $@ $<
+
+include $(patsubst %.o, $(OBJDIR)/%.d, $(OBJ))
 
 clean:
-	rm -rf $(OBJS) $(EXE) $(EXE).b64
+	rm -rf $(TARGET) $(BUILD_DIR) obj

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+    make:
+        build: .
+        volumes:
+            - type: bind
+              source: ./code
+              target: /build


### PR DESCRIPTION
Use docker-compose to avoid the local glibc version mismatching the remote glibc version.